### PR TITLE
Add years in public office and make scroller a dynamic (no ssr) component

### DIFF
--- a/components/BillCard/BillCard.tsx
+++ b/components/BillCard/BillCard.tsx
@@ -1,30 +1,19 @@
-import styles from "./BillCard.module.scss"
+import Link from "next/link";
+import styles from "./BillCard.module.scss";
+import type { BillResult } from "generated";
 
-type Bill = {
-  billNumber: string,
-  title: string,
-  legislationStatus:string,
-}
-
-const BillCard = ({
-  bill,
-  itemId
-} : {
-  bill: Bill,
-  itemId: string
-}) => {
-
+const BillCard = ({ bill }: { bill: Partial<BillResult> }) => {
   return (
-    <div className={styles.billCard}>
-      <div className={styles.cardContent}>
-        <h1 className={styles.billNumber}>{bill.billNumber}</h1>
-        <h2 className={styles.billTitle}>{bill.title}</h2>
-        <span className={styles.statusPill}>
-          {bill.legislationStatus}
-        </span>
+    <Link href={`/bills/${bill.slug}`} key={bill.slug} passHref>
+      <div className={styles.billCard}>
+        <div className={styles.cardContent}>
+          <h1 className={styles.billNumber}>{bill.billNumber}</h1>
+          <h2 className={styles.billTitle}>{bill.title}</h2>
+          <span className={styles.statusPill}>{bill.legislationStatus}</span>
+        </div>
       </div>
-    </div>
-  )
-}
+    </Link>
+  );
+};
 
-export default BillCard
+export default BillCard;

--- a/components/Scroller/Scroller.tsx
+++ b/components/Scroller/Scroller.tsx
@@ -1,3 +1,4 @@
+import dynamic from "next/dynamic";
 import { ReactElement, useContext } from "react";
 import { ScrollMenu, VisibilityContext } from "react-horizontal-scrolling-menu";
 
@@ -24,22 +25,15 @@ function RightArrow() {
 }
 
 type ScrollerItem = ReactElement<{
-  /**
-      Required. id for every item, should be unique
-     */
-  itemId: string;
-}>
+  itemId: string; // Required. id for every item, should be unique
+}>;
 
-function Scroller(props: {
-  children: ScrollerItem | ScrollerItem[]
-}) {
+function Scroller(props: { children: ScrollerItem | ScrollerItem[] }) {
   return (
     <div className={styles.horizontalScrollContainer}>
-      <ScrollMenu>
-        {props.children}
-      </ScrollMenu>
+      <ScrollMenu>{props.children}</ScrollMenu>
     </div>
-  )
+  );
 }
 
-export default Scroller
+export default Scroller;

--- a/generated.ts
+++ b/generated.ts
@@ -750,6 +750,12 @@ export type PoliticianResult = {
   votesmartCandidateBio: GetCandidateBioResponse;
   votesmartCandidateId: Scalars['Int'];
   websiteUrl?: Maybe<Scalars['String']>;
+  /**
+   * Calculates the total years a politician has been in office using
+   * the votesmart politicial experience array.  Does not take into account
+   * objects where the politician is considered a 'candidate'
+   */
+  yearsInPublicOffice: Scalars['Int'];
 };
 
 export type PoliticianResultConnection = {
@@ -1161,7 +1167,7 @@ export type PoliticianBySlugQueryVariables = Exact<{
 }>;
 
 
-export type PoliticianBySlugQuery = { __typename?: 'Query', politicianBySlug: { __typename?: 'PoliticianResult', fullName: string, nickname?: string | null | undefined, preferredName?: string | null | undefined, homeState: State, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, websiteUrl?: string | null | undefined, twitterUrl?: string | null | undefined, facebookUrl?: string | null | undefined, instagramUrl?: string | null | undefined, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, termStart: string, termEnd: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string } }, sponsoredBills: Array<{ __typename?: 'BillResult', billNumber: string, title: string, legislationStatus: LegislationStatus }>, endorsements: { __typename?: 'Endorsements', organizations: Array<{ __typename?: 'OrganizationResult', id: string, slug: string, name: string, thumbnailImageUrl?: string | null | undefined }> } } };
+export type PoliticianBySlugQuery = { __typename?: 'Query', politicianBySlug: { __typename?: 'PoliticianResult', fullName: string, nickname?: string | null | undefined, preferredName?: string | null | undefined, homeState: State, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, websiteUrl?: string | null | undefined, twitterUrl?: string | null | undefined, facebookUrl?: string | null | undefined, instagramUrl?: string | null | undefined, yearsInPublicOffice: number, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, termStart: string, termEnd: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string, congMembership: any } }, sponsoredBills: Array<{ __typename?: 'BillResult', slug: string, billNumber: string, title: string, legislationStatus: LegislationStatus }>, endorsements: { __typename?: 'Endorsements', organizations: Array<{ __typename?: 'OrganizationResult', id: string, slug: string, name: string, thumbnailImageUrl?: string | null | undefined }>, politicians: Array<{ __typename?: 'PoliticianResult', id: string, slug: string, fullName: string, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined }> } } };
 
 
 export const OrganizationBySlugDocument = /*#__PURE__*/ `
@@ -1286,6 +1292,7 @@ export const PoliticianBySlugDocument = /*#__PURE__*/ `
     twitterUrl
     facebookUrl
     instagramUrl
+    yearsInPublicOffice
     votesmartCandidateBio {
       office {
         name
@@ -1294,9 +1301,11 @@ export const PoliticianBySlugDocument = /*#__PURE__*/ `
       }
       candidate {
         photo
+        congMembership
       }
     }
     sponsoredBills {
+      slug
       billNumber
       title
       legislationStatus
@@ -1306,6 +1315,13 @@ export const PoliticianBySlugDocument = /*#__PURE__*/ `
         id
         slug
         name
+        thumbnailImageUrl
+      }
+      politicians {
+        id
+        slug
+        fullName
+        officeParty
         thumbnailImageUrl
       }
     }

--- a/graphql/queries/politicians.graphql
+++ b/graphql/queries/politicians.graphql
@@ -43,18 +43,22 @@ query PoliticianBySlug($slug: String!) {
     twitterUrl
     facebookUrl
     instagramUrl
+    yearsInPublicOffice
     votesmartCandidateBio {
       office {
         name
         termStart
         termEnd
       }
+
       candidate {
         photo
+        congMembership
       }
     }
 
     sponsoredBills {
+      slug
       billNumber
       title
       legislationStatus
@@ -65,6 +69,13 @@ query PoliticianBySlug($slug: String!) {
         id
         slug
         name
+        thumbnailImageUrl
+      }
+      politicians {
+        id
+        slug
+        fullName
+        officeParty
         thumbnailImageUrl
       }
     }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -550,6 +550,13 @@ type PoliticianResult {
   votesmartCandidateBio: GetCandidateBioResponse!
   votesmartCandidateId: Int!
   websiteUrl: String
+
+  """
+  Calculates the total years a politician has been in office using
+  the votesmart politicial experience array.  Does not take into account
+  objects where the politician is considered a 'candidate'
+  """
+  yearsInPublicOffice: Int!
 }
 
 type PoliticianResultConnection {

--- a/pages/politicians/[slug].tsx
+++ b/pages/politicians/[slug].tsx
@@ -2,24 +2,23 @@ import type { GetServerSideProps, NextPage } from "next";
 import { NextParsedUrlQuery } from "next/dist/server/request-meta";
 import Link from "next/link";
 import Image from "next/image";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useContext, useEffect } from "react";
 import { dehydrate, QueryClient } from "react-query";
 
-import {
-  BillCard,
-  Layout,
-  LoaderFlag,
-  PartyAvatar,
-  Scroller,
-  Spacer,
-} from "components";
+import { BillCard, Layout, LoaderFlag, PartyAvatar } from "components";
 
-import { useAppContext } from "context/App";
+// Note: this is a dynamic import because the react-horizontal-scrolling-menu
+// uses useLayoutEffect which is not supported by the server.
+const Scroller = dynamic(() => import("components/Scroller/Scroller"), {
+  ssr: false,
+});
 
 import {
+  OrganizationResult,
   PoliticalParty,
   PoliticianBySlugQuery,
+  PoliticianResult,
   usePoliticianBySlugQuery,
 } from "../../generated";
 
@@ -35,13 +34,11 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   const { query } = useRouter();
   const slug = query.slug as string;
   const { data, isLoading, error } = usePoliticianBySlugQuery({ slug });
-  const { dispatch } = useAppContext();
 
   if (isLoading) return <LoaderFlag />;
-
   if (error) return <p>Error: {error}</p>;
-
   const politician = data?.politicianBySlug;
+  if (!politician) return <p>No politician found</p>;
 
   const sponsoredBills = politician?.sponsoredBills;
 
@@ -52,10 +49,10 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   const termStart = getYear(
     politician?.votesmartCandidateBio.office?.termStart as string
   );
-
   const termEnd = getYear(
     politician?.votesmartCandidateBio.office?.termEnd as string
   );
+  const yearsInPublicOffice = politician?.yearsInPublicOffice;
 
   const endorsements = politician?.endorsements;
 
@@ -94,16 +91,19 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
             <span>{termEnd}</span>
           </p>
         )}
+        {/* Dont have this datapoint yet */}
         {/* <p className={styles.flexBetween}>
-            <span>Elections Won / Lost</span>
-            <span className={styles.dots} />
-            <span>-</span>
-          </p>
+          <span>Elections Won / Lost</span>
+          <span className={styles.dots} />
+          <span>-</span>
+        </p> */}
+        {!!yearsInPublicOffice && (
           <p className={styles.flexBetween}>
             <span>Years in Public Office</span>
             <span className={styles.dots} />
-            <span>-</span>
-          </p> */}
+            <span>{yearsInPublicOffice}</span>
+          </p>
+        )}
       </section>
     );
   }
@@ -150,23 +150,19 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   }
 
   function CommitteesSection() {
-    // TODO Replace with data here
-    const tags = [
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-      "Economy",
-      "Finance",
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-      "Conservation, Forestry, Environment, Etc. Long Long Long",
-    ];
+    const tags =
+      politician?.votesmartCandidateBio?.candidate?.congMembership?.experience?.map(
+        (committee: any) =>
+          committee.organization.replace("Subcommittee on", "")
+      ) ?? [];
 
     const tagPageSize = 4;
     const tagPages: string[][] = Array(Math.ceil(tags.length / tagPageSize))
       .fill("")
       .map((_, index) => index * tagPageSize)
       .map((begin) => tags.slice(begin, begin + tagPageSize));
+
+    if (tags.length === 0) return null;
 
     return (
       <section className={styles.center}>
@@ -191,11 +187,7 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
         {sponsoredBills && (
           <Scroller>
             {sponsoredBills.map((bill) => (
-              <BillCard
-                bill={bill}
-                key={bill.billNumber}
-                itemId={bill.billNumber}
-              />
+              <BillCard bill={bill} key={bill.slug} />
             ))}
           </Scroller>
         )}
@@ -203,17 +195,10 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
     );
   }
 
-  function Endorsement({
+  function OrganizationEndorsement({
     organization,
-    itemId,
   }: {
-    organization: {
-      id: string;
-      slug: string;
-      name: string;
-      thumbnailImageUrl?: string | null;
-    };
-    itemId: string;
+    organization: Partial<OrganizationResult>;
   }) {
     return (
       <Link
@@ -240,21 +225,67 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
     );
   }
 
+  function PoliticianEndorsement({
+    politician,
+  }: {
+    politician: Partial<PoliticianResult>;
+  }) {
+    return (
+      <Link
+        href={`/politicians/${politician.slug}`}
+        key={politician.id}
+        passHref
+      >
+        <div className={styles.organizationContainer}>
+          {politician.thumbnailImageUrl ? (
+            <div className={styles.organizationAvatar}>
+              <Image
+                src={politician.thumbnailImageUrl}
+                alt={politician.fullName}
+                width={50}
+                height={50}
+              />
+            </div>
+          ) : (
+            <span>No Image</span>
+          )}
+          <h4>{politician.fullName}</h4>
+        </div>
+      </Link>
+    );
+  }
+
   function EndorsementsSection() {
-    if (!endorsements) return null;
+    if (!endorsements?.organizations && !endorsements?.politicians) return null;
     return (
       <section className={styles.center}>
-        <h3 className={styles.gradientHeader}>Endorsements</h3>
-        <h3>Organizations</h3>
-        <Scroller>
-          {endorsements.organizations.map((organization) => (
-            <Endorsement
-              organization={organization}
-              key={organization.slug}
-              itemId={organization.slug}
-            />
-          ))}
-        </Scroller>
+        {endorsements.organizations.length > 0 && (
+          <>
+            <h3 className={styles.gradientHeader}>Endorsements</h3>
+            <h3>Organizations</h3>
+            <Scroller>
+              {endorsements.organizations.map((organization) => (
+                <OrganizationEndorsement
+                  organization={organization}
+                  key={organization.slug}
+                />
+              ))}
+            </Scroller>
+          </>
+        )}
+        {endorsements.politicians.length > 0 && (
+          <>
+            <h3>Individuals</h3>
+            <Scroller>
+              {endorsements.politicians.map((politician) => (
+                <PoliticianEndorsement
+                  politician={politician}
+                  key={politician.slug}
+                />
+              ))}
+            </Scroller>
+          </>
+        )}
       </section>
     );
   }

--- a/styles/politicianPage.module.scss
+++ b/styles/politicianPage.module.scss
@@ -57,7 +57,7 @@
 
 .gradientHeader {
   width: 100%;
-  margin: -1rem 0 1rem !important;
+  margin: -2rem 0 1rem !important;
   padding: 1rem;
   background: linear-gradient(180deg, #003c55 0%, #002e45 100%);
   text-align: center;


### PR DESCRIPTION
# Description
- Adds `yearsInPublicOffice` to politicianBySlug query
- Uses this value in the general info section of politician/[slug]
- Dynamically imports the scroller components because they use `useLayoutEffect` which does not work server side
- Replaces Bill type with generated `BillResult` type
- Link BillCard to bill page (not yet implemented)
- Implements Committee Tags from api data (strips out `Subcommittee for`) 
- Updates endorsement section to match new API