### PR TITLE
Update mobile politician page

### DIFF
--- a/components/Scroller/Scroller.module.scss
+++ b/components/Scroller/Scroller.module.scss
@@ -8,7 +8,6 @@
 
 .scrollPage {
   @include for-tablet-portrait-down {
-
     min-width: 100%;
   }
 }

--- a/components/Scroller/Scroller.module.scss
+++ b/components/Scroller/Scroller.module.scss
@@ -1,5 +1,14 @@
+@import "styles/mixins";
+
 .horizontalScrollContainer {
-  margin: 1rem -1rem;
+  margin: 1rem 0;
   max-width: 100%;
   max-height: max-content;
+}
+
+.scrollPage {
+  @include for-tablet-portrait-down {
+
+    min-width: 100%;
+  }
 }

--- a/components/Scroller/Scroller.tsx
+++ b/components/Scroller/Scroller.tsx
@@ -28,10 +28,13 @@ type ScrollerItem = ReactElement<{
   itemId: string; // Required. id for every item, should be unique
 }>;
 
-function Scroller(props: { children: ScrollerItem | ScrollerItem[] }) {
+function Scroller(props: {
+  children: ScrollerItem | ScrollerItem[];
+  onePageAtATime?: boolean;
+}) {
   return (
     <div className={styles.horizontalScrollContainer}>
-      <ScrollMenu>{props.children}</ScrollMenu>
+      <ScrollMenu itemClassName={props.onePageAtATime ? styles.scrollPage : ""}>{props.children}</ScrollMenu>
     </div>
   );
 }

--- a/generated.ts
+++ b/generated.ts
@@ -7,7 +7,7 @@ export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Mayb
 
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
   return async (): Promise<TData> => {
-    const res = await fetch("https://api.staging.populist.us/", {
+    const res = await fetch("https://api.populist.us/", {
     method: "POST",
     ...({"headers":{"Content-Type":"application/json","Accept-Encoding":"gzip"}}),
       body: JSON.stringify({ query, variables }),
@@ -1386,7 +1386,7 @@ export type PoliticianBySlugQueryVariables = Exact<{
 }>;
 
 
-export type PoliticianBySlugQuery = { __typename?: 'Query', politicianBySlug: { __typename?: 'PoliticianResult', id: string, fullName: string, nickname?: string | null | undefined, preferredName?: string | null | undefined, homeState: State, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, websiteUrl?: string | null | undefined, twitterUrl?: string | null | undefined, facebookUrl?: string | null | undefined, instagramUrl?: string | null | undefined, yearsInPublicOffice: number, upcomingRace?: { __typename?: 'RaceResult', raceType: string, officePosition: string, state?: State | null | undefined, electionDate?: any | null | undefined, candidates: Array<{ __typename?: 'PoliticianResult', id: string, slug: string, fullName: string, thumbnailImageUrl?: string | null | undefined, officeParty?: PoliticalParty | null | undefined }> } | null | undefined, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, termStart: string, termEnd: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string, congMembership: any } }, sponsoredBills: { __typename?: 'BillResultConnection', edges?: Array<{ __typename?: 'BillResultEdge', node: { __typename?: 'BillResult', slug: string, billNumber: string, title: string, legislationStatus: LegislationStatus } } | null | undefined> | null | undefined }, endorsements: { __typename?: 'Endorsements', organizations: Array<{ __typename?: 'OrganizationResult', id: string, slug: string, name: string, thumbnailImageUrl?: string | null | undefined }>, politicians: Array<{ __typename?: 'PoliticianResult', id: string, slug: string, fullName: string, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, district: string, typeField: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string } } }> } } };
+export type PoliticianBySlugQuery = { __typename?: 'Query', politicianBySlug: { __typename?: 'PoliticianResult', id: string, fullName: string, nickname?: string | null | undefined, preferredName?: string | null | undefined, homeState: State, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, websiteUrl?: string | null | undefined, twitterUrl?: string | null | undefined, facebookUrl?: string | null | undefined, instagramUrl?: string | null | undefined, yearsInPublicOffice: number, upcomingRace?: { __typename?: 'RaceResult', raceType: string, officePosition: string, state?: State | null | undefined, electionDate?: any | null | undefined, candidates: Array<{ __typename?: 'PoliticianResult', id: string, slug: string, fullName: string, thumbnailImageUrl?: string | null | undefined, officeParty?: PoliticalParty | null | undefined }> } | null | undefined, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, termStart: string, termEnd: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string, congMembership: any } }, sponsoredBills: { __typename?: 'BillResultConnection', edges?: Array<{ __typename?: 'BillResultEdge', node: { __typename?: 'BillResult', slug: string, billNumber: string, title: string, legislationStatus: LegislationStatus } } | null | undefined> | null | undefined }, endorsements: { __typename?: 'Endorsements', organizations: Array<{ __typename?: 'OrganizationResult', id: string, slug: string, name: string, thumbnailImageUrl?: string | null | undefined }>, politicians: Array<{ __typename?: 'PoliticianResult', id: string, slug: string, fullName: string, homeState: State, officeParty?: PoliticalParty | null | undefined, thumbnailImageUrl?: string | null | undefined, currentOffice?: { __typename?: 'OfficeResult', id: string, slug: string, title: string, municipality?: string | null | undefined, district?: string | null | undefined, state?: State | null | undefined, officeType?: string | null | undefined } | null | undefined, votesmartCandidateBio: { __typename?: 'GetCandidateBioResponse', office?: { __typename?: 'Office', name: Array<string>, district: string, typeField: string } | null | undefined, candidate: { __typename?: 'Candidate', photo: string } } }> } } };
 
 
 export const OrganizationBySlugDocument = /*#__PURE__*/ `
@@ -1567,8 +1567,18 @@ export const PoliticianBySlugDocument = /*#__PURE__*/ `
         id
         slug
         fullName
+        homeState
         officeParty
         thumbnailImageUrl
+        currentOffice {
+          id
+          slug
+          title
+          municipality
+          district
+          state
+          officeType
+        }
         votesmartCandidateBio {
           office {
             name

--- a/generated.ts
+++ b/generated.ts
@@ -372,6 +372,7 @@ export type CreatePoliticianInput = {
   upcomingRaceId?: InputMaybe<Scalars['UUID']>;
   votesmartCandidateBio?: InputMaybe<Scalars['JSON']>;
   votesmartCandidateId?: InputMaybe<Scalars['Int']>;
+  votesmartCandidateRatings?: InputMaybe<Scalars['JSON']>;
   websiteUrl?: InputMaybe<Scalars['String']>;
 };
 
@@ -1327,6 +1328,7 @@ export type UpdatePoliticianInput = {
   upcomingRaceId?: InputMaybe<Scalars['UUID']>;
   votesmartCandidateBio?: InputMaybe<Scalars['JSON']>;
   votesmartCandidateId?: InputMaybe<Scalars['Int']>;
+  votesmartCandidateRatings?: InputMaybe<Scalars['JSON']>;
   websiteUrl?: InputMaybe<Scalars['String']>;
 };
 

--- a/graphql/queries/politicians.graphql
+++ b/graphql/queries/politicians.graphql
@@ -110,8 +110,18 @@ query PoliticianBySlug($slug: String!) {
         id
         slug
         fullName
+        homeState
         officeParty
         thumbnailImageUrl
+        currentOffice {
+          id
+          slug
+          title
+          municipality
+          district
+          state
+          officeType
+        }
         votesmartCandidateBio {
           office {
             name

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -302,6 +302,7 @@ input CreatePoliticianInput {
   upcomingRaceId: UUID
   votesmartCandidateBio: JSON
   votesmartCandidateId: Int
+  votesmartCandidateRatings: JSON
   websiteUrl: String
 }
 
@@ -1034,6 +1035,7 @@ input UpdatePoliticianInput {
   upcomingRaceId: UUID
   votesmartCandidateBio: JSON
   votesmartCandidateId: Int
+  votesmartCandidateRatings: JSON
   websiteUrl: String
 }
 

--- a/pages/politicians/[slug].tsx
+++ b/pages/politicians/[slug].tsx
@@ -27,6 +27,8 @@ import styles from "styles/politicianPage.module.scss";
 
 import states from "util/states";
 
+import { computeShortOfficeTitle } from "util/politician";
+
 const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   mobileNavTitle,
 }: {
@@ -205,7 +207,7 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
     return (
       <section className={styles.center}>
         <h3>Committees</h3>
-        <Scroller>
+        <Scroller onePageAtATime>
           {tagPages.map((tagPage, index) => (
             <CommitteeTagPage
               tags={tagPage}
@@ -279,6 +281,7 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   }: {
     politician: Partial<PoliticianResult>;
   }) {
+    const officeTitle = computeShortOfficeTitle(politician)
     return (
       <Link
         href={`/politicians/${politician.slug}`}
@@ -289,8 +292,10 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
           <PartyAvatar
             party={(politician.officeParty as PoliticalParty) || "DEMOCRATIC"}
             src={politician?.votesmartCandidateBio?.candidate.photo as string}
+            size={"5rem"}
           />
           <h4>{politician.fullName}</h4>
+          {officeTitle && <span className={styles.politicianEndorsementOffice}>{officeTitle}</span>}
         </div>
       </Link>
     );

--- a/pages/politicians/[slug].tsx
+++ b/pages/politicians/[slug].tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
+import { useMemo } from "react"
 import { dehydrate, QueryClient } from "react-query";
 
 import { BillCard, Layout, LoaderFlag, PartyAvatar } from "components";
@@ -281,7 +282,7 @@ const PoliticianPage: NextPage<{ mobileNavTitle?: string }> = ({
   }: {
     politician: Partial<PoliticianResult>;
   }) {
-    const officeTitle = computeShortOfficeTitle(politician)
+    const officeTitle = useMemo(() => computeShortOfficeTitle(politician), [politician])
     return (
       <Link
         href={`/politicians/${politician.slug}`}

--- a/pages/politicians/index.tsx
+++ b/pages/politicians/index.tsx
@@ -25,38 +25,13 @@ import type { PoliticianResult } from "../../generated";
 import useDeviceInfo from "hooks/useDeviceInfo";
 import useDebounce from "hooks/useDebounce";
 import { NextPageWithLayout } from "../_app";
+import { computeOfficeTitle } from "util/politician"
 
 const PAGE_SIZE = 20;
 
 const PoliticianRow = ({ politician }: { politician: PoliticianResult }) => {
   const { isMobile } = useDeviceInfo();
-
-  const officeTitle =
-    politician?.currentOffice?.title ||
-    politician.votesmartCandidateBio.office?.title;
-  const officeType =
-    politician.currentOffice?.officeType ||
-    politician.votesmartCandidateBio.office?.typeField;
-
-  const computeOfficeTitle = () => {
-    switch (true) {
-      case officeType === "State Legislative" && officeTitle === "Senator":
-        return `${politician.homeState} Senate`;
-      case officeType === "State Legislative" &&
-        officeTitle === "Representative":
-        return `${politician.homeState} House`;
-      case officeType === "Local Executive":
-        return `${politician.currentOffice?.municipality ?? ""} ${officeTitle}`;
-      case officeTitle === "Senator":
-        return "U.S. Congress";
-      case officeTitle === "Representative":
-        return "U.S. House";
-      default:
-        return officeTitle;
-    }
-  };
-
-  const officeTitleDisplay = computeOfficeTitle();
+  const officeTitleDisplay = computeOfficeTitle(politician);
   const district = politician.votesmartCandidateBio.office?.district;
 
   const districtDisplay =

--- a/styles/politicianPage.module.scss
+++ b/styles/politicianPage.module.scss
@@ -141,7 +141,15 @@
     -webkit-line-clamp: 2;
     line-clamp: 2;
     -webkit-box-orient: vertical;
+    margin: 1rem 0 0.375rem;
   }
+}
+
+.politicianEndorsementOffice {
+  font-size: $text-sm;
+  color: $aqua;
+  font-style: italic;
+  text-align: center;
 }
 
 .organizationAvatar {

--- a/util/politician.tsx
+++ b/util/politician.tsx
@@ -1,0 +1,69 @@
+import type { PoliticianResult } from "../generated";
+
+const computeOfficeTitle = (politician: Partial<PoliticianResult>) => {
+  const officeTitle =
+    politician?.currentOffice?.title ||
+    politician?.votesmartCandidateBio?.office?.title;
+  const officeType =
+    politician?.currentOffice?.officeType ||
+    politician?.votesmartCandidateBio?.office?.typeField;
+  switch (true) {
+    case officeType === "State Legislative" && officeTitle === "Senator":
+      return `${politician.homeState} Senate`;
+    case officeType === "State Legislative" &&
+      officeTitle === "Representative":
+      return `${politician.homeState} House`;
+    case officeType === "Local Executive":
+      return `${politician.currentOffice?.municipality ?? ""} ${officeTitle}`;
+    case officeTitle === "Senator":
+      return "U.S. Congress";
+    case officeTitle === "Representative":
+      return "U.S. House";
+    default:
+      return officeTitle;
+  }
+};
+
+const computeShortOfficeTitle = (politician: Partial<PoliticianResult>) => {
+
+  const districtDisplay = (includePrefix: boolean, includeDash: boolean) => {
+    const district = politician.votesmartCandidateBio?.office?.district;
+    if (!district) return ""
+    const districtWithPrefix = !district || isNaN(+district) || !includePrefix ? district : `D ${district}`;
+    return (includeDash ? " - " : "") + districtWithPrefix;
+  }
+  
+  const officeTitle =
+    politician?.currentOffice?.title ||
+    politician?.votesmartCandidateBio?.office?.title || "";
+  const officeType =
+    politician?.currentOffice?.officeType ||
+    politician?.votesmartCandidateBio?.office?.typeField || "";
+  const state = politician?.currentOffice?.state || politician?.homeState || ""
+
+  switch (true) {
+    case officeType === "State Legislative" && (
+      officeTitle === "Senator" || officeTitle === "State Senate"
+    ):
+      return `${state} Sen.${districtDisplay(true, true)}`;
+    case officeType === "State Legislative" && (
+      officeTitle === "Representative" || officeTitle === "State House"
+    ):
+      return `${state} Rep.${districtDisplay(true, true)}`;
+    case officeType === "Local Executive":
+      return `${politician.currentOffice?.municipality ?? ""} ${officeTitle} - ${state} ${districtDisplay(true, true)}`;
+    case officeTitle === "Senator":
+      return `U.S. Sen. - ${state} ${districtDisplay(false, false)}`;
+    case officeTitle === "Representative":
+      return `U.S. Rep. - ${state} ${districtDisplay(false, false)}`;
+    case officeType === "Congressional":
+      return `${officeTitle.replace("House", "Rep.").replace("Senate", "Sen.")} - ${state} ${districtDisplay(false, false)}`
+    default:
+      return `${officeTitle} - ${state} ${districtDisplay(false, false)}`;
+  }
+}
+
+export {
+  computeOfficeTitle,
+  computeShortOfficeTitle
+}


### PR DESCRIPTION
- Render only one page of tags at once 
- Update politician endorsements query to return more office info
- Update endorsements UI to render office with region info (there's definitely some room to cleanup here based on the `officeType` and `officeTitle`)