### PR TITLE
Add better caching for currentUserQuery

### DIFF
--- a/components/Auth/LogIn/LogIn.tsx
+++ b/components/Auth/LogIn/LogIn.tsx
@@ -22,7 +22,10 @@ function LogIn() {
   const [loginError, setLoginError] = useState<string | null>(null);
 
   const getCurrentUser = useCurrentUserQuery();
-  const { data, isLoading } = useCurrentUserQuery();
+  const { data, isLoading } = useCurrentUserQuery(undefined, {
+    gcTime: 1000 * 60 * 15, // 15 minutes
+    staleTime: 1000 * 60 * 15, // 15 minutes
+  });
   const user = data?.currentUser;
   if (user) void router.push(`/${router.query.next || "/home"}`);
 


### PR DESCRIPTION
This pull request includes an update to the `LogIn` component to optimize the fetching behavior of the current user query.

Optimizations to fetching behavior:

* [`components/Auth/LogIn/LogIn.tsx`](diffhunk://#diff-5103ee954d55a201e8016ca475dce377e9e579d1e09ce069865ebd0ab013f2e1L25-R28): Updated the `useCurrentUserQuery` to include `gcTime` and `staleTime` options, both set to 15 minutes, to improve caching and reduce unnecessary network requests.